### PR TITLE
issues #2 #4 Bugfix and YAML support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,13 @@
 [![Latest Stable Version](https://poser.pugx.org/alicemajere/wonderland-container/v/stable.png)](https://packagist.org/packages/alicemajere/wonderland-container)
 [![Total Downloads](https://poser.pugx.org/alicemajere/wonderland-container/downloads)](https://packagist.org/packages/alicemajere/wonderland-container)
 
-
 # Wonderland Container
 
 A small simple service container to include in projects
 
 ## Recent Update
 
-The project just got released on packagist with release 1.0.0. 
+Update 1.1.0 available. Check the [release page](https://github.com/AliceMajere/wonderland-container/releases) for the changelog
 
 ## Installation
 
@@ -83,6 +82,47 @@ $newInstance = $container->get('service.name', true);
 // the service is not a definition service but a instance definition service; only the shared instance will be retrieved
 $instance = $container->get('service.name2');
 ```
+
+### Loading configuration with YAML files
+
+``` php
+$container = new \Wonderland\Container\ServiceContainer();
+$serviceLoader = new \Wonderland\Container\Configuration\ServiceLoader(new YamlParser());
+// load every yml in a folder
+$container->loadServices($serviceLoader->loadDirectory(__DIR__ . '/Resource/'));
+// or a single file
+$container->loadServices($serviceLoader->loadFile(__DIR__ . '/Resource/test.yml'));
+```
+
+Yaml file examples 
+``` yaml
+services:
+    service.name:
+        class: Wonderland\Container\Example\Yml\SampleClass
+        arguments:
+            - 'param1'
+            - 'param2'
+        calls:
+            callMethod:
+                - 'param11'
+                - 'param22'
+    service.name2:
+        class: Wonderland\Container\Example\Yml\SampleClass
+        arguments:
+            - 'param3'
+            - 'param4'
+        calls:
+            callMethod:
+                - 'param33'
+                - 'param44'
+
+    service.name3:
+        class: \DateTime             
+```
+
+## Examples
+
+You can check out the `examples` folder for more running examples of the library.
 
 ## Prerequisites
 

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,14 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Wonderland\\Container\\Tests\\": "tests/unit/"
+            "Wonderland\\Container\\Tests\\": "tests/unit/",
+            "Wonderland\\Container\\Example\\": "examples/"
         }
     },
     "require": {
         "php": ">=7.2",
-        "psr/container": "^1.0"
+        "psr/container": "^1.0",
+        "symfony/yaml": "^4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "71409c99063d0bc0da133bf25e5a1ec3",
+    "content-hash": "417c891505ca8be261a50580ea37e78e",
     "packages": [
         {
             "name": "psr/container",
@@ -54,6 +54,123 @@
                 "psr"
             ],
             "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2018-08-06T14:22:27+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v4.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "367e689b2fdc19965be435337b50bc8adf2746c9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/367e689b2fdc19965be435337b50bc8adf2746c9",
+                "reference": "367e689b2fdc19965be435337b50bc8adf2746c9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/console": "<3.4"
+            },
+            "require-dev": {
+                "symfony/console": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-10-02T16:36:10+00:00"
         }
     ],
     "packages-dev": [

--- a/examples/Object/SampleClass.php
+++ b/examples/Object/SampleClass.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Wonderland\Container\Example\Object;
+
+/**
+ * Class SampleClass
+ * @package Wonderland\Container\Example\Object
+ * @author Alice Praud <alice.majere@gmail.com>
+ */
+class SampleClass
+{
+	private $first;
+	private $second;
+
+	public function __construct($param1, $param2)
+	{
+		$this->first = $param1;
+		$this->second = $param2;
+	}
+
+	public function callMethod($param1, $param2)
+	{
+		$this->first = $param1;
+		$this->second = $param2;
+	}
+}

--- a/examples/Object/object.php
+++ b/examples/Object/object.php
@@ -1,0 +1,35 @@
+<?php
+
+if ( !is_readable( __DIR__ . '/../../vendor/autoload.php' ) ) {
+	die( 'You need to install this package with Composer before you can run the examples' );
+}
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+$container = new \Wonderland\Container\ServiceContainer();
+
+// Create a new definition with another service as an argument
+$definition = new \Wonderland\Container\Service\ServiceDefinition(
+	'service.name',
+	\Wonderland\Container\Example\Object\SampleClass::class,
+	['param1', '@service.name2']
+);
+
+// Create a new definition with a method call taking two other services as arguments
+$definition2 = new \Wonderland\Container\Service\ServiceDefinition(
+	'service.name2',
+	\Wonderland\Container\Example\Object\SampleClass::class,
+	['param2', 'param3'],
+	['callMethod' => ['test', '@instance.name']]
+);
+
+// Create a new instance definition
+$instance = new \Wonderland\Container\Service\InstanceDefinition(
+	'instance.name',
+	new \DateTime()
+);
+
+// Registering them all
+$container->addService($definition);
+$container->addService($definition2);
+$container->addServiceInstance($instance);

--- a/examples/Yml/Resource/test.yml
+++ b/examples/Yml/Resource/test.yml
@@ -1,0 +1,10 @@
+services:
+    service.name:
+        class: Wonderland\Container\Example\Yml\SampleClass
+        arguments:
+            - 'param1'
+            - 'param2'
+        calls:
+            callMethod:
+                - 'param11'
+                - 'param22'

--- a/examples/Yml/Resource/test2.yml
+++ b/examples/Yml/Resource/test2.yml
@@ -1,0 +1,16 @@
+services:
+    service.name2:
+        class: Wonderland\Container\Example\Yml\SampleClass
+        arguments:
+            - 'param3'
+            - 'param4'
+        calls:
+            callMethod:
+                - 'param33'
+                - 'param44'
+
+    service.name3:
+        class: Wonderland\Container\Example\Yml\SampleClass
+        arguments:
+            - '@service.name'
+            - '@service.name2'

--- a/examples/Yml/SampleClass.php
+++ b/examples/Yml/SampleClass.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Wonderland\Container\Example\Yml;
+
+/**
+ * Class SampleClass
+ * @package Wonderland\Container\Example\Yml
+ * @author Alice Praud <alice.majere@gmail.com>
+ */
+class SampleClass
+{
+	private $first;
+	private $second;
+
+	public function __construct($param1, $param2)
+	{
+		$this->first = $param1;
+		$this->second = $param2;
+	}
+
+	public function callMethod($param1, $param2)
+	{
+		$this->first = $param1;
+		$this->second = $param2;
+	}
+}

--- a/examples/Yml/yml.php
+++ b/examples/Yml/yml.php
@@ -1,0 +1,21 @@
+<?php
+
+if ( !is_readable( __DIR__ . '/../../vendor/autoload.php' ) ) {
+	die( 'You need to install this package with Composer before you can run the examples' );
+}
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use Wonderland\Container\Configuration\Parser\YamlParser;
+
+// Load by directory
+$container = new \Wonderland\Container\ServiceContainer();
+$serviceLoader = new \Wonderland\Container\Configuration\ServiceLoader(new YamlParser());
+$container->loadServices($serviceLoader->loadDirectory(__DIR__ . '/Resource/'));
+
+// Load file by file
+$container2 = new \Wonderland\Container\ServiceContainer();
+$serviceLoader = new \Wonderland\Container\Configuration\ServiceLoader(new YamlParser());
+$container2->loadServices($serviceLoader->loadFile(__DIR__ . '/Resource/test.yml'));
+$container2->loadServices($serviceLoader->loadFile(__DIR__ . '/Resource/test2.yml'));
+

--- a/src/Configuration/Config/Fields.php
+++ b/src/Configuration/Config/Fields.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Wonderland\Container\Configuration\Config;
+
+/**
+ * Class Fields
+ * @package Wonderland\Container\Configuration\Config
+ * @author Alice Praud <alice.majere@gmail.com>
+ */
+final class Fields
+{
+	const ROOT_CONFIG_NAME = 'services';
+	const CLASS_CONFIG_NAME = 'class';
+	const CONSTRUCTOR_PARAMS_CONFIG_NAME = 'arguments';
+	const METHOD_CALLS_CONFIG_NAME = 'calls';
+}

--- a/src/Configuration/Parser/ParserInterface.php
+++ b/src/Configuration/Parser/ParserInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Wonderland\Container\Configuration\Parser;
+
+/**
+ * Interface ParserInterface
+ * @package Wonderland\Container\Configuration\Parser
+ * @author Alice Praud <alice.majere@gmail.com>
+ */
+interface ParserInterface
+{
+
+	/**
+	 * @param string $filePath
+	 * @return array
+	 */
+	public function loadFile(string $filePath): array;
+
+	/**
+	 * @param string $directorPath
+	 * @return array
+	 */
+	public function loadDirectory(string $directorPath): array;
+
+}

--- a/src/Configuration/Parser/YamlParser.php
+++ b/src/Configuration/Parser/YamlParser.php
@@ -32,7 +32,11 @@ class YamlParser implements ParserInterface
 
 		$parse = Yaml::parseFile($filePath);
 
-		return false === is_array($parse) ? [] : $parse;
+		if (false === is_array($parse)) {
+			$parse = [];
+		}
+
+		return $parse;
 	}
 
 	/**

--- a/src/Configuration/Parser/YamlParser.php
+++ b/src/Configuration/Parser/YamlParser.php
@@ -32,7 +32,7 @@ class YamlParser implements ParserInterface
 
 		$parse = Yaml::parseFile($filePath);
 
-		return null === $parse ? [] : $parse;
+		return false === is_array($parse) ? [] : $parse;
 	}
 
 	/**

--- a/src/Configuration/Parser/YamlParser.php
+++ b/src/Configuration/Parser/YamlParser.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Wonderland\Container\Configuration\Parser;
+
+use Symfony\Component\Yaml\Yaml;
+use Wonderland\Container\Exception\InvalidResourceException;
+use Wonderland\Container\Exception\ResourceNotFoundException;
+
+/**
+ * Class Yaml
+ * @package Wonderland\Container\Configuration\Parser
+ * @author Alice Praud <alice.majere@gmail.com>
+ */
+class YamlParser implements ParserInterface
+{
+
+	/**
+	 * @param string $filePath
+	 * @return array
+	 * @throws ResourceNotFoundException
+	 * @throws InvalidResourceException
+	 */
+	public function loadFile(string $filePath): array
+	{
+		if (false === file_exists($filePath)) {
+			throw new ResourceNotFoundException('The file "' . $filePath . '" does not exists');
+		}
+
+		if (false === is_file($filePath)) {
+			throw new InvalidResourceException('The resource "' . $filePath . '" is not a file');
+		}
+
+		$parse = Yaml::parseFile($filePath);
+
+		return null === $parse ? [] : $parse;
+	}
+
+	/**
+	 * @param string $directorPath
+	 * @return array
+	 * @throws InvalidResourceException
+	 * @throws ResourceNotFoundException
+	 */
+	public function loadDirectory(string $directorPath): array
+	{
+		if (false === file_exists($directorPath)) {
+			throw new ResourceNotFoundException('The directory "' . $directorPath . '" does not exists');
+		}
+
+		if (false === is_dir($directorPath)) {
+			throw new InvalidResourceException('The resource "' . $directorPath . '" is not a directory');
+		}
+
+		$config = [];
+
+		$files = array_diff(scandir($directorPath), array('.', '..'));
+		foreach ($files as $file) {
+			if (false !== preg_match('/^.+(yml|yaml)$/i', $file)) {
+				$config[$file] = Yaml::parseFile(realpath($directorPath) . DIRECTORY_SEPARATOR . $file);
+			}
+		}
+
+		return $config;
+	}
+
+}

--- a/src/Configuration/ServiceLoader.php
+++ b/src/Configuration/ServiceLoader.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Wonderland\Container\Configuration;
+
+use Wonderland\Container\Configuration\Config\Fields;
+use Wonderland\Container\Configuration\Parser\ParserInterface;
+use Wonderland\Container\Configuration\Validator\ConfigurationValidator;
+use Wonderland\Container\Exception\InvalidConfigFormatException;
+use Wonderland\Container\Service\ServiceDefinition;
+
+/**
+ * Class ServiceLoader
+ * @package Wonderland\Container\Configuration
+ * @author Alice Praud <alice.majere@gmail.com>
+ */
+class ServiceLoader
+{
+	/** @var ParserInterface  */
+	private $parser;
+
+	/** @var ConfigurationValidator  */
+	private $validator;
+
+	/**
+	 * ServiceLoader constructor.
+	 * @param ParserInterface $parser
+	 */
+	public function __construct(ParserInterface $parser)
+	{
+		$this->parser = $parser;
+		$this->validator = new ConfigurationValidator();
+	}
+
+	/**
+	 * @param string $filePath
+	 * @return ServiceDefinition[]
+	 * @throws InvalidConfigFormatException
+	 */
+	public function loadFile(string $filePath)
+	{
+		$definitionList = $this->parser->loadFile($filePath);
+
+		return $this->loadDefinitions($definitionList);
+	}
+
+	/**
+	 * @param string $directoryPath
+	 * @return ServiceDefinition[]
+	 * @throws InvalidConfigFormatException
+	 */
+	public function loadDirectory(string $directoryPath)
+	{
+		$definitionList = $this->parser->loadDirectory($directoryPath);
+
+		$list = [];
+		foreach ($definitionList as $item) {
+			$list = array_merge($list, $this->loadDefinitions($item));
+		}
+
+		return $list;
+	}
+
+	/**
+	 * @param array $definitionList
+	 * @return ServiceDefinition[]
+	 * @throws InvalidConfigFormatException
+	 */
+	private function loadDefinitions(array $definitionList)
+	{
+		$this->validator->validateDefinitions($definitionList);
+
+		if (null === $definitionList[Fields::ROOT_CONFIG_NAME]) {
+			return [];
+		}
+
+		$list = [];
+		foreach ($definitionList[Fields::ROOT_CONFIG_NAME] as $serviceName => $serviceConfig) {
+			$list[] = $this->initServiceDefinition($serviceName, $serviceConfig);
+		}
+
+		return $list;
+	}
+
+	/**
+	 * @param string $serviceName
+	 * @param array $serviceConfig
+	 * @return ServiceDefinition
+	 */
+	private function initServiceDefinition(string $serviceName, array $serviceConfig)
+	{
+		$definition = new ServiceDefinition(
+			$serviceName,
+			$this->getClass($serviceConfig),
+			$this->getConstructorParams($serviceConfig),
+			$this->getMethodCalls($serviceConfig)
+		);
+
+		return $definition;
+	}
+
+	/**
+	 * @param $serviceConfig
+	 * @return string
+	 */
+	private function getClass($serviceConfig)
+	{
+		return $serviceConfig[Fields::CLASS_CONFIG_NAME];
+	}
+
+	/**
+	 * @param $serviceConfig
+	 * @return array
+	 */
+	private function getConstructorParams($serviceConfig)
+	{
+		if (false === array_key_exists(Fields::CONSTRUCTOR_PARAMS_CONFIG_NAME, $serviceConfig)) {
+			return [];
+		}
+
+		return $serviceConfig[Fields::CONSTRUCTOR_PARAMS_CONFIG_NAME];
+	}
+
+	/**
+	 * @param $serviceConfig
+	 * @return array
+	 */
+	private function getMethodCalls($serviceConfig)
+	{
+		if (false === array_key_exists(Fields::METHOD_CALLS_CONFIG_NAME, $serviceConfig)) {
+			return [];
+		}
+
+		return $serviceConfig[Fields::METHOD_CALLS_CONFIG_NAME];
+	}
+
+}

--- a/src/Configuration/Validator/ConfigurationValidator.php
+++ b/src/Configuration/Validator/ConfigurationValidator.php
@@ -65,6 +65,17 @@ class ConfigurationValidator
 			);
 		}
 
+		$this->validateClass($service);
+		$this->validateArguments($service);
+		$this->validateMethods($service);
+	}
+
+	/**
+	 * @param $service
+	 * @throws InvalidConfigFormatException
+	 */
+	private function validateClass($service)
+	{
 		if (false === array_key_exists(Fields::CLASS_CONFIG_NAME, $service)) {
 			throw new InvalidConfigFormatException(
 				self::ERROR_PREFIX . ' key "' . Fields::CLASS_CONFIG_NAME . '" is required'
@@ -76,7 +87,14 @@ class ConfigurationValidator
 				self::ERROR_PREFIX . ' key "' . Fields::CLASS_CONFIG_NAME . '" must be a string'
 			);
 		}
+	}
 
+	/**
+	 * @param $service
+	 * @throws InvalidConfigFormatException
+	 */
+	private function validateArguments($service)
+	{
 		if (true === array_key_exists(Fields::CONSTRUCTOR_PARAMS_CONFIG_NAME, $service) &&
 			false === is_array($service[Fields::CONSTRUCTOR_PARAMS_CONFIG_NAME])
 		) {
@@ -85,7 +103,14 @@ class ConfigurationValidator
 				'" must be an array or null'
 			);
 		}
+	}
 
+	/**
+	 * @param $service
+	 * @throws InvalidConfigFormatException
+	 */
+	private function validateMethods($service)
+	{
 		if (true === array_key_exists(Fields::METHOD_CALLS_CONFIG_NAME, $service) &&
 			false === is_array($service[Fields::METHOD_CALLS_CONFIG_NAME])
 		) {

--- a/src/Configuration/Validator/ConfigurationValidator.php
+++ b/src/Configuration/Validator/ConfigurationValidator.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Wonderland\Container\Configuration\Validator;
+
+use Wonderland\Container\Configuration\Config\Fields;
+use Wonderland\Container\Exception\InvalidConfigFormatException;
+
+/**
+ * TODO find a better way to validate later
+ * Class ServiceValidator
+ * @package Wonderland\Container\Configuration\Validator
+ * @author Alice Praud <alice.majere@gmail.com>
+ */
+class ConfigurationValidator
+{
+	private const ERROR_PREFIX = 'The service configuration';
+
+	/**
+	 * @param array $definitionList
+	 * @throws InvalidConfigFormatException
+	 */
+	public function validateDefinitions(array $definitionList)
+	{
+		$this->validateRoot($definitionList);
+
+		if (null === $definitionList[Fields::ROOT_CONFIG_NAME]) {
+			return;
+		}
+
+		foreach ($definitionList[Fields::ROOT_CONFIG_NAME] as $serviceName => $service) {
+			$this->validateService($serviceName, $service);
+		}
+	}
+
+	/**
+	 * @param array $definitionList
+	 * @throws InvalidConfigFormatException
+	 */
+	private function validateRoot(array $definitionList)
+	{
+		if (false === array_key_exists(Fields::ROOT_CONFIG_NAME, $definitionList)) {
+			throw new InvalidConfigFormatException(
+				self::ERROR_PREFIX . ' need the root config key "' . Fields::ROOT_CONFIG_NAME . '"'
+			);
+		}
+
+		$field = $definitionList[Fields::ROOT_CONFIG_NAME];
+		if (false === is_array($field) && false === is_null($field)) {
+			throw new InvalidConfigFormatException(
+				self::ERROR_PREFIX . ' key "' . Fields::ROOT_CONFIG_NAME . '" must be an associative array'
+			);
+		}
+	}
+
+	/**
+	 * @param $serviceName
+	 * @param $service
+	 * @throws InvalidConfigFormatException
+	 */
+	private function validateService($serviceName, $service)
+	{
+		if (false === is_array($service)) {
+			throw new InvalidConfigFormatException(
+				self::ERROR_PREFIX . ' key "' . $serviceName . '" must be an associative array'
+			);
+		}
+
+		if (false === array_key_exists(Fields::CLASS_CONFIG_NAME, $service)) {
+			throw new InvalidConfigFormatException(
+				self::ERROR_PREFIX . ' key "' . Fields::CLASS_CONFIG_NAME . '" is required'
+			);
+		}
+
+		if (false === is_string($service[Fields::CLASS_CONFIG_NAME])) {
+			throw new InvalidConfigFormatException(
+				self::ERROR_PREFIX . ' key "' . Fields::CLASS_CONFIG_NAME . '" must be a string'
+			);
+		}
+
+		if (true === array_key_exists(Fields::CONSTRUCTOR_PARAMS_CONFIG_NAME, $service) &&
+			false === is_array($service[Fields::CONSTRUCTOR_PARAMS_CONFIG_NAME])
+		) {
+			throw new InvalidConfigFormatException(
+				self::ERROR_PREFIX . ' key "' . Fields::CONSTRUCTOR_PARAMS_CONFIG_NAME .
+				'" must be an array or null'
+			);
+		}
+
+		if (true === array_key_exists(Fields::METHOD_CALLS_CONFIG_NAME, $service) &&
+			false === is_array($service[Fields::METHOD_CALLS_CONFIG_NAME])
+		) {
+			throw new InvalidConfigFormatException(
+				self::ERROR_PREFIX . ' key "' . Fields::METHOD_CALLS_CONFIG_NAME .
+				'" must be an array or null'
+			);
+		}
+
+		if (false === array_key_exists(Fields::METHOD_CALLS_CONFIG_NAME, $service)) {
+			return;
+		}
+
+		foreach ($service[Fields::METHOD_CALLS_CONFIG_NAME] as $methodName => $call) {
+			$this->validateCalls($methodName, $call);
+		}
+	}
+
+	/**
+	 * @param $methodName
+	 * @param $call
+	 * @throws InvalidConfigFormatException
+	 */
+	private function validateCalls($methodName, $call)
+	{
+		if (false === is_array($call)) {
+			throw new InvalidConfigFormatException(
+				self::ERROR_PREFIX . ' key "' . $methodName . '" must be be an array'
+			);
+		}
+	}
+
+}

--- a/src/Exception/InvalidConfigFormatException.php
+++ b/src/Exception/InvalidConfigFormatException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Wonderland\Container\Exception;
+
+/**
+ * Class InvalidConfigFormatException
+ * @package Wonderland\Container\Exception
+ * @author Alice Praud <alice.majere@gmail.com>
+ */
+class InvalidConfigFormatException extends \Exception
+{
+
+}

--- a/src/Exception/InvalidResourceException.php
+++ b/src/Exception/InvalidResourceException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Wonderland\Container\Exception;
+
+/**
+ * Class InvalidResourceException
+ * @package Wonderland\Container\Exception
+ * @author Alice Praud <alice.majere@gmail.com>
+ */
+class InvalidResourceException extends \Exception
+{
+
+}

--- a/src/Exception/ResourceNotFoundException.php
+++ b/src/Exception/ResourceNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Wonderland\Container\Exception;
+
+/**
+ * Class ResourceNotFoundException
+ * @package Wonderland\Container\Exception
+ * @author Alice Praud <alice.majere@gmail.com>
+ */
+class ResourceNotFoundException extends \Exception
+{
+
+}

--- a/src/Service/InstanceDefinition.php
+++ b/src/Service/InstanceDefinition.php
@@ -7,7 +7,7 @@ namespace Wonderland\Container\Service;
  * @package Wonderland\Container\Container\Service
  * @author Alice Praud <alice.majere@gmail.com>
  */
-class InstanceDefinition implements ServiceInstanceInterface
+class InstanceDefinition implements InstanceDefinitionInterface
 {
 	/** @var string */
 	private $serviceName;

--- a/src/Service/InstanceDefinitionInterface.php
+++ b/src/Service/InstanceDefinitionInterface.php
@@ -3,12 +3,11 @@
 namespace Wonderland\Container\Service;
 
 /**
- * @deprecated use InstanceDefinitionInterface instead
  * Interface ServiceInstanceInterface
  * @package Wonderland\Container\Container\Service
  * @author Alice Praud <alice.majere@gmail.com>
  */
-interface ServiceInstanceInterface
+interface InstanceDefinitionInterface
 {
 
 	/** @return string */

--- a/tests/unit/Configuration/Parser/YamlParserTest.php
+++ b/tests/unit/Configuration/Parser/YamlParserTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Wonderland\Container\Tests\Configuration\Parser;
+
+use PHPUnit\Framework\TestCase;
+use Wonderland\Container\Configuration\Parser\YamlParser;
+use Wonderland\Container\Exception\InvalidResourceException;
+use Wonderland\Container\Exception\ResourceNotFoundException;
+
+/**
+ * Class YamlParserTest
+ * @package Wonderland\Container\Tests\Configuration\Parser
+ * @author Alice Praud <alice.majere@gmail.com>
+ */
+class YamlParserTest extends TestCase
+{
+	/** @var YamlParser */
+	private $parser;
+
+	public function setUp()
+	{
+		$this->parser = new YamlParser();
+	}
+
+	/**
+	 * @throws \Wonderland\Container\Exception\InvalidResourceException
+	 * @throws \Wonderland\Container\Exception\ResourceNotFoundException
+	 */
+	public function test_load()
+	{
+		$this->assertInternalType('array', $this->parser->loadFile(__DIR__ . '/../data/yml/test-full.yml'));
+		$this->assertInternalType('array', $this->parser->loadDirectory(__DIR__ . '/../data/yml/'));
+	}
+
+	/**
+	 * @return array
+	 */
+	public function loadErrorNotFoundProvider()
+	{
+		return [
+			['dontexists']
+		];
+	}
+
+	/**
+	 * @dataProvider loadErrorNotFoundProvider
+	 * @param string $filePath
+	 * @throws \Wonderland\Container\Exception\InvalidResourceException
+	 * @throws \Wonderland\Container\Exception\ResourceNotFoundException
+	 */
+	public function test_loadFileErrorNotFound($filePath)
+	{
+		$this->expectException(ResourceNotFoundException::class);
+		$this->parser->loadFile($filePath);
+	}
+
+	/**
+	 * @dataProvider loadErrorNotFoundProvider
+	 * @param string $filePath
+	 * @throws \Wonderland\Container\Exception\InvalidResourceException
+	 * @throws \Wonderland\Container\Exception\ResourceNotFoundException
+	 */
+	public function test_loadDirErrorNotFound($filePath)
+	{
+		$this->expectException(ResourceNotFoundException::class);
+		$this->parser->loadDirectory($filePath);
+	}
+
+	/**
+	 * @throws \Wonderland\Container\Exception\InvalidResourceException
+	 * @throws \Wonderland\Container\Exception\ResourceNotFoundException
+	 */
+	public function test_loadFileErrorInvalid()
+	{
+		$this->expectException(InvalidResourceException::class);
+		$this->parser->loadFile(__DIR__ . '/../data/yml');
+	}
+
+	/**
+	 * @throws \Wonderland\Container\Exception\InvalidResourceException
+	 * @throws \Wonderland\Container\Exception\ResourceNotFoundException
+	 */
+	public function test_loadDirErrorInvalid()
+	{
+		$this->expectException(InvalidResourceException::class);
+		$this->parser->loadDirectory(__DIR__ . '/../data/yml/test-full.yml');
+	}
+
+}

--- a/tests/unit/Configuration/ServiceLoaderTest.php
+++ b/tests/unit/Configuration/ServiceLoaderTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Wonderland\Container\Tests\Configuration;
+
+use PHPUnit\Framework\TestCase;
+use Wonderland\Container\Configuration\Parser\YamlParser;
+use Wonderland\Container\Configuration\ServiceLoader;
+use Wonderland\Container\Exception\InvalidConfigFormatException;
+use Wonderland\Container\Service\ServiceDefinition;
+
+/**
+ * Class ServiceLoader
+ * @package Wonderland\Container\Tests\Configuration
+ * @author Alice Praud <alice.majere@gmail.com>
+ */
+class ServiceLoaderTest extends TestCase
+{
+	/** @var ServiceLoader */
+	private $loaderYml;
+
+	public function setUp()
+	{
+		$this->loaderYml = new ServiceLoader(new YamlParser());
+	}
+
+	/**
+	 * @return array
+	 */
+	public function ymlProvider()
+	{
+		return [
+			[__DIR__ . '/data/yml/test-empty.yml'],
+			[__DIR__ . '/data/yml/test-full.yml']
+		];
+	}
+
+	/**
+	 * @dataProvider ymlProvider
+	 * @param string $testFile
+	 * @throws \Wonderland\Container\Exception\InvalidConfigFormatException
+	 */
+	public function test_loadFile($testFile)
+	{
+		$services = $this->loaderYml->loadFile($testFile);
+		$this->assertInternalType('array', $services);
+		foreach ($services as $service) {
+			$this->assertInstanceOf(ServiceDefinition::class, $service);
+		}
+	}
+
+	/**
+	 * @return array
+	 */
+	public function ymlErrorProvider()
+	{
+		return [
+			[__DIR__ . '/data/yml-error/empty.yml'],
+			[__DIR__ . '/data/yml-error/err1.yml'],
+			[__DIR__ . '/data/yml-error/err2.yml'],
+			[__DIR__ . '/data/yml-error/err3.yml'],
+			[__DIR__ . '/data/yml-error/err4.yml'],
+			[__DIR__ . '/data/yml-error/err5.yml'],
+			[__DIR__ . '/data/yml-error/err6.yml'],
+			[__DIR__ . '/data/yml-error/err7.yml'],
+			[__DIR__ . '/data/yml-error/err8.yml']
+		];
+	}
+
+	/**
+	 * @dataProvider ymlErrorProvider
+	 * @param string $testFile
+	 * @throws \Wonderland\Container\Exception\InvalidConfigFormatException
+	 */
+	public function test_loadFileError($testFile)
+	{
+		$this->expectException(InvalidConfigFormatException::class);
+		$this->loaderYml->loadFile($testFile);
+	}
+
+	/**
+	 * @throws InvalidConfigFormatException
+	 */
+	public function test_loadDirectory()
+	{
+		$services = $this->loaderYml->loadDirectory(__DIR__ . '/data/yml');
+		$this->assertInternalType('array', $services);
+		foreach ($services as $service) {
+			$this->assertInstanceOf(ServiceDefinition::class, $service);
+		}
+	}
+
+}

--- a/tests/unit/Configuration/data/yml-error/err1.yml
+++ b/tests/unit/Configuration/data/yml-error/err1.yml
@@ -1,0 +1,2 @@
+services: test
+

--- a/tests/unit/Configuration/data/yml-error/err2.yml
+++ b/tests/unit/Configuration/data/yml-error/err2.yml
@@ -1,0 +1,3 @@
+services:
+    servicename: ~
+

--- a/tests/unit/Configuration/data/yml-error/err3.yml
+++ b/tests/unit/Configuration/data/yml-error/err3.yml
@@ -1,0 +1,4 @@
+services:
+    servicename: test
+
+

--- a/tests/unit/Configuration/data/yml-error/err4.yml
+++ b/tests/unit/Configuration/data/yml-error/err4.yml
@@ -1,0 +1,5 @@
+services:
+    servicename:
+        -
+
+

--- a/tests/unit/Configuration/data/yml-error/err5.yml
+++ b/tests/unit/Configuration/data/yml-error/err5.yml
@@ -1,0 +1,5 @@
+services:
+    servicename:
+        class: ~
+
+

--- a/tests/unit/Configuration/data/yml-error/err6.yml
+++ b/tests/unit/Configuration/data/yml-error/err6.yml
@@ -1,0 +1,6 @@
+services:
+    servicename:
+        class: \DateTime
+        arguments: ~
+
+

--- a/tests/unit/Configuration/data/yml-error/err7.yml
+++ b/tests/unit/Configuration/data/yml-error/err7.yml
@@ -1,0 +1,8 @@
+services:
+    servicename:
+        class: \DateTime
+        arguments:
+            -
+        calls: ~
+
+

--- a/tests/unit/Configuration/data/yml-error/err8.yml
+++ b/tests/unit/Configuration/data/yml-error/err8.yml
@@ -1,0 +1,9 @@
+services:
+    servicename:
+        class: \DateTime
+        arguments:
+            -
+        calls:
+            method: ~
+
+

--- a/tests/unit/Configuration/data/yml/test-empty.yml
+++ b/tests/unit/Configuration/data/yml/test-empty.yml
@@ -1,0 +1,1 @@
+services:

--- a/tests/unit/Configuration/data/yml/test-full.yml
+++ b/tests/unit/Configuration/data/yml/test-full.yml
@@ -1,0 +1,16 @@
+services:
+    service1:
+        class: \Datetime
+        arguments:
+            - '1970-01-01'
+
+    service2:
+        class: \Datetime
+        arguments:
+            - '2018-12-31'
+        calls:
+            format:
+                - 'Y-m-d'
+
+    service3:
+        class: \Datetime

--- a/tests/unit/ServiceContainerTest.php
+++ b/tests/unit/ServiceContainerTest.php
@@ -159,18 +159,31 @@ class ServiceContainerTest extends TestCase
 		$this->realContainer->addServiceInstance(
 			new InstanceDefinition('call.format', 'd-m-Y')
 		);
+		$this->realContainer->addServiceInstance(
+			new InstanceDefinition('call.date', '1970-01-01')
+		);
 
 		$this->realContainer->addService(
 			new ServiceDefinition(
 				'service.call',
 				\DateTime::class,
+				['@call.date'],
+				['format' => ['@call.format']]
+			)
+		);
+
+		$this->realContainer->addService(
+			new ServiceDefinition(
+				'service.call2',
+				\DateTime::class,
 				['1970-01-01'],
-				['format' => ['call.format']]
+				['format' => ['Y-m-d']]
 			)
 		);
 
 		$date = new \DateTime('1970-01-01');
 		$this->assertSame($date->format('m-d-Y'), $this->realContainer->get('service.call')->format('m-d-Y'));
+		$this->assertSame($date->format('m-d-Y'), $this->realContainer->get('service.call2')->format('m-d-Y'));
 	}
 
 	public function test_has()
@@ -178,6 +191,9 @@ class ServiceContainerTest extends TestCase
 		$this->assertSame(false, $this->realContainer->has('fake'));
 		$this->assertSame(true, $this->realContainer->has(self::DEFAULT_SERVICE_NANE));
 		$this->assertSame(true, $this->realContainer->has(self::DEFAULT_SERVICE_NANE));
+
+		$this->realContainer->addServiceInstance(new InstanceDefinition('instance.name', \DateTime::class));
+		$this->assertSame(true, $this->realContainer->has('instance.name'));
 	}
 
 }


### PR DESCRIPTION
- Added YAML configuration files support for loading services definitions.
- Service name references now need the character '@' at the start of their name.
- Fixed a bug where services references wouldn't load properly when passed as a method call arguments
- Interface ServiceInstanceInterface marked as deprecated. Replaced by InstanceDefinitionInterface
- Added the examples folder with running examples on how to run the library. Use composer require --dev to use them